### PR TITLE
Set node minimum version to 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "memoisation"
   ],
   "license": "MIT",
+  "engines": {
+    "node": ">=12"
+  },
   "devDependencies": {
     "ts-node": "^10.5.0",
     "typescript": "^4.5.5"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,8 @@
 {
+  "extends": "@tsconfig/node12/tsconfig.json",
   "compilerOptions": {
-    "target": "es2016",
-    "module": "commonjs",
-    "esModuleInterop": true,
     "declaration": true,
-    "forceConsistentCasingInFileNames": true,
-    "experimentalDecorators": true,
-    "strict": true,
-    "skipLibCheck": true
+    "experimentalDecorators": true
   },
   "include": [
     "./src/**/*.ts"


### PR DESCRIPTION
No real reason for that particular version, but good to define some minimum.

No changes to distributed js source since 0.1.1. Verified manually.